### PR TITLE
Remove intermediate structures when encoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,28 @@
 mod arguments;
 mod encoding;
 
-use encoding::bencode::{ByteStr, Int, List, Dict, ListEntry, DictEntry, Literal, Error};
+use encoding::bencode::{Error, Encodable, DictionaryEntry, Dictionary};
 
 fn main() -> Result<(), Error> {
 
     println!("String unwrap test:");
-    match ByteStr::try_from_str("Hello, World!") {
-        Ok(v) => println!("{}", v.stringify()?),
-        Err(e) => println!("{:?}", e)
-    };
+    println!("{}", String::from("Hello, World!").encode()?);
 
     println!("Int unwrap test:");
-    let i = Int::from(-0);
-    println!("{}", i.stringify()?);
+    println!("{}", (-0 as isize).encode()?);
 
     println!("List unwrap test:");
-    let arr: Vec<ListEntry> = vec![Box::new(Int::from(5)), Box::new(Int::from(10))];
-    let l = List::from(arr);
-    println!("{}", l.stringify()?);
+    let list: Vec<Box<dyn Encodable>> = vec![Box::new(1 as isize), Box::new("owo")];
+    println!("{}", list.encode()?);
 
     println!("Dict unwrap test:");
-    let arr: Vec<DictEntry> = vec![(ByteStr::try_from_str("TestKey")?, Box::new(i))];
-    let d = Dict::from(arr);
-    println!("{}", d.stringify()?);
+    let dict: Dictionary = vec![
+        DictionaryEntry::new("Key1", "Elem1"),
+        DictionaryEntry::new("Key2", 2 as u8),
+        DictionaryEntry::new("List1", list)
+    ];
+    println!("{}", dict.encode()?);
+
 
     Ok(())
 }


### PR DESCRIPTION
Changes:
- Instead of having to convert `String` into `ByteStr` or integers into `Int`, this makes it so that encoding can be called directly from the data to be encoded
- Dictionaries are encoded with keys sorted lexicographically
- Function and trait names for encoding have been changed from `Literal` and `stringify` to `Encodable` and `encode`, however this is not as important

Reasoning:
- There is no need for these intermediate structures since the data in these intermediate structures is the same as the original
- It is bencoding specification to sort dictionaries by key when encoding

<br><br>

For example, this is now possible:
```rust
let my_string = String::from("Hello, World!");
println!("{}", my_string.encode().unwrap()); // 13:Hello, World!
```

Lists and dictionaries have also been updated to adopt this change:
```rust
let list: Vec<Box<dyn Encodable>> = vec![Box:new(1u8), Box::new("two")];
println!("{}", list.encode()?); // li1e3:twoe

let dict: Vec<DictionaryEntry> = vec![
        DictionaryEntry::new("Key1", "Elem1"),
        DictionaryEntry::new("Key2", 2 as u8),
        DictionaryEntry::new("AlphabeticalOrder", list)
];
println!("{}", dict.encode()?); // d17:AlphabeticalOrderli1e3:twoe4:Key15:Elem14:Key2i2ee
```
